### PR TITLE
Set up SFML with orange background and closing with X or ESC

### DIFF
--- a/SFMLTutorials/SFMLTutorials.vcxproj
+++ b/SFMLTutorials/SFMLTutorials.vcxproj
@@ -76,10 +76,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)\External\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)\External\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>sfml-window-d.lib;sfml-system-d.lib;sfml-graphics-d.lib;sfml-audio-d.lib;sfml-network-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -91,12 +95,15 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)\External\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)\External\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>sfml-window.lib;sfml-system.lib;sfml-graphics.lib;sfml-audio.lib;sfml-network.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -105,10 +112,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)\External\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)\External\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>sfml-window-d.lib;sfml-system-d.lib;sfml-graphics-d.lib;sfml-audio-d.lib;sfml-network-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -120,12 +131,15 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)\External\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)\External\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>sfml-window.lib;sfml-system.lib;sfml-graphics.lib;sfml-audio.lib;sfml-network.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/SFMLTutorials/main.cpp
+++ b/SFMLTutorials/main.cpp
@@ -1,5 +1,32 @@
 #include <iostream>
+#include <SFML/Graphics.hpp>
 
 int main() {
-	std::cout << "Hello World\n";
+	unsigned int width = 640;
+	unsigned int height = 360;
+	sf::RenderWindow* window = new sf::RenderWindow(sf::VideoMode({ width, height }), "Tutorials");
+
+	while (window->isOpen()) {
+		while (const std::optional event = window->pollEvent()) {
+			// Close the window
+			if (event->is<sf::Event::Closed>()) {
+				window->close();
+			}
+
+			// Close if Esc key pressed
+			else if (const auto* keyPressed = event->getIf<sf::Event::KeyPressed>()) {
+				if (keyPressed->scancode == sf::Keyboard::Scancode::Escape) {
+					window->close();
+				}
+			}
+		}
+
+		// Render
+		window->clear(sf::Color(0xFF8800FF)); // Background color to Orange
+
+		// Drawing
+		window->display();
+	}
+	delete window;
+	return 0;
 }


### PR DESCRIPTION
## Tests
- Debug opened a window with orange background
- X or Esc button closed the window
- Pressing "F" did not impact the window

## Explanation
Set up in (here)[https://www.youtube.com/watch?v=lftcRWAIycg]

1. download Windows Visual Studio C++ 17 32 bit version to support more
2. run Debug x86 (runs 32 bit apps) in visual studio 2022

3. Property of Project changes

In Visual Studio 2022, changing the C++ Language Standard setting in a project's properties (found under C/C++ > Language > C++ Language Standard) determines which version of the C++ programming language standard the compiler uses when building your code. This affects the syntax, features, and behaviors available to you in your C++ code.

In Visual Studio 2022, modifying the C/C++ > General > Additional Include Directories setting in a project's properties specifies additional paths where the compiler looks for header files (e.g., .h, .hpp) during the compilation phase. This setting is crucial when your project uses external libraries or custom header files located outside the default search paths.

---
Linking is the phase where the linker (a part of the build toolchain) combines various compiled object files and libraries into a single executable file (or sometimes a library) that can be run on a computer.

The linker takes these object files, along with any libraries, and "links" them together by filling in the missing pieces—resolving those references—and producing a complete, executable program (e.g., .exe on Windows).

If your program uses external libraries (e.g., sfml-window-d.lib), the linker includes the necessary code from those libraries or sets up references to dynamically loaded libraries (DLLs or shared objects). ---

In Visual Studio 2022, modifying the Linker > General > Additional Library Directories setting in a project's properties specifies additional paths where the linker should look for library files (e.g., .lib files) during the linking phase of the build process.

When you modify the Linker > Input > Additional Dependencies setting in Visual Studio 2022 to include sfml-window-d.lib in your project's properties, you're instructing the linker to include the SFML (Simple and Fast Multimedia Library) window module's debug library during the linking phase of your build process.

Add these to Debug Additional Dependencies
sfml-window-d.lib
sfml-system-d.lib
sfml-graphics-d.lib
sfml-audio-d.lib
sfml-network-d.lib

Add these to Release Additional Dependencies
sfml-window.lib
sfml-system.lib
sfml-graphics.lib
sfml-audio.lib
sfml-network.lib

---
The -d suffix in sfml-window-d.lib stands for debug. It indicates that this is the debug version of the library. sfml-window.lib (without the -d) is the release version of the library. ---